### PR TITLE
Translate *.-dev branches too

### DIFF
--- a/bin/splitcore
+++ b/bin/splitcore
@@ -24,7 +24,7 @@ IFB_BIN=${IFB_PATH}/incremental-git-filterbranch
 # Perform the incremental filter-branch operation
 "${IFB_BIN}" \
 	--workdir "${WORK_DIR}" \
-	--branch-whitelist 'develop master rx:release\/.*' \
+	--branch-whitelist 'develop master rx:.*-dev rx:release\/.*' \
 	--tag-blacklist 'rx:5\..*' \
 	--prune-branches --prune-tags \
 	--tags-plan all --tags-max-history-lookup 10 \


### PR DESCRIPTION
This should fix the issue of not having the 8.4.3 tag translated from https://github.com/concrete5/concrete5 to https://github.com/concrete5/concrete5-core