### PR TITLE
 Allow customizing the location of log and data directories 

### DIFF
--- a/bin/splitcore
+++ b/bin/splitcore
@@ -5,9 +5,6 @@ set -o errexit
 # Treat unset variables and parameters other than the special parameters "@" and "*" as an error when performing parameter expansion.
 set -o nounset
 
-# The version of https://github.com/concrete5/incremental-filter-branch to be used
-IFB_VERSION=1.0.2
-
 # Store in SCRIPT_DIR the directory that contains this script
 # Please remark that this won't work in case of symlinks/hardlinks
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)

--- a/bin/splitcore
+++ b/bin/splitcore
@@ -13,7 +13,11 @@ IFB_VERSION=1.0.2
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 
 # Store in WORK_DIR the directory that will contain the working repositories
-WORK_DIR=${SCRIPT_DIR}/../temp
+if test -z "${SPLITCORE_DATADIR:-}"; then
+	WORK_DIR=${SCRIPT_DIR}/../temp
+else
+	WORK_DIR=$SPLITCORE_DATADIR/temp
+fi
 
 # Store in IFB_PATH the path of the incremental-filter-branch directory
 IFB_PATH=${SCRIPT_DIR}/../vendor/bin

--- a/bin/splitcore_logged
+++ b/bin/splitcore_logged
@@ -10,7 +10,11 @@ set -o nounset
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 
 # Store in LOG_DIR the directory that will contain the logs
-LOG_DIR=${SCRIPT_DIR}/../logs
+if test -z "${SPLITCORE_DATADIR:-}"; then
+	LOG_DIR=${SCRIPT_DIR}/../logs
+else
+	LOG_DIR=$SPLITCORE_DATADIR/logs
+fi
 
 # Store in LOG_FILE the full path of the log file
 # The log file will be in format YYYY-MM.log in UTC time (-u), so we'll have one log file per month


### PR DESCRIPTION
Bacause of the wey this splitcore package is installed on the server, we don't keep logs. This greatly nullify the log feature, and makes debugging a lot harder.

So, what about adding support to specifying a custom location where data is stored? This can be specified by setting a `SPLITCORE_DATADIR` environment variable.