### PR TITLE
Fix allowlist of branches

### DIFF
--- a/bin/splitcore
+++ b/bin/splitcore
@@ -25,7 +25,7 @@ IFB_BIN=${IFB_PATH}/incremental-git-filterbranch
 # Perform the incremental filter-branch operation
 "${IFB_BIN}" \
 	--workdir "${WORK_DIR}" \
-	--branch-whitelist 'develop master 9.0rc rx:.*-dev rx:.*\.x rx:release\/.*' \
+	--branch-whitelist 'master rx:.+\.x rx:.+-dev rx:release\/.*' \
 	--tag-blacklist 'rx:5\..*' \
 	--prune-branches --prune-tags \
 	--tags-plan all --tags-max-history-lookup 10 \


### PR DESCRIPTION
1. We don't have `develop` anymore
2. We don't have `9.0rc` anymore
3. Let's accept branches ending with `-dev` (but that are not named *exactly* `-dev`)
4. Let's accept branches ending with `.x` (but that are not named *exactly* `.x`)